### PR TITLE
Make immovable rod deal damage instead of gibbing

### DIFF
--- a/Content.Server/ImmovableRod/ImmovableRodComponent.cs
+++ b/Content.Server/ImmovableRod/ImmovableRodComponent.cs
@@ -39,6 +39,6 @@ public sealed partial class ImmovableRodComponent : Component
     public bool DestroyTiles = true;
 
     // Sector Umbra
-    [DataField("damage")]
-    public DamageSpecifier Damage;
+    [DataField("damage", required: true)]
+    public DamageSpecifier Damage = default!;
 }

--- a/Content.Server/ImmovableRod/ImmovableRodComponent.cs
+++ b/Content.Server/ImmovableRod/ImmovableRodComponent.cs
@@ -1,3 +1,4 @@
+using Content.Shared.Damage;
 using Robust.Shared.Audio;
 
 namespace Content.Server.ImmovableRod;
@@ -36,4 +37,8 @@ public sealed partial class ImmovableRodComponent : Component
     /// </summary>
     [DataField("destroyTiles")]
     public bool DestroyTiles = true;
+
+    // Sector Umbra
+    [DataField("damage")]
+    public DamageSpecifier Damage;
 }

--- a/Content.Server/ImmovableRod/ImmovableRodSystem.cs
+++ b/Content.Server/ImmovableRod/ImmovableRodSystem.cs
@@ -3,6 +3,7 @@ using Content.Server.Popups;
 using Content.Shared.Body.Components;
 using Content.Shared.Examine;
 using Content.Shared.Popups;
+using Content.Shared.Damage;
 using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Map;
@@ -22,6 +23,7 @@ public sealed class ImmovableRodSystem : EntitySystem
     [Dependency] private readonly PopupSystem _popup = default!;
     [Dependency] private readonly SharedPhysicsSystem _physics = default!;
     [Dependency] private readonly SharedAudioSystem _audio = default!;
+    [Dependency] private readonly DamageableSystem _damageableSystem = default!; // Sector Umbra
 
     public override void Update(float frameTime)
     {
@@ -100,7 +102,8 @@ public sealed class ImmovableRodSystem : EntitySystem
             component.MobCount++;
 
             _popup.PopupEntity(Loc.GetString("immovable-rod-penetrated-mob", ("rod", uid), ("mob", ent)), uid, PopupType.LargeCaution);
-            _bodySystem.GibBody(ent, body: body);
+            // Sector Umbra: deal damage instead of gibbing
+            _damageableSystem.TryChangeDamage(ent, component.Damage, ignoreResistances: true, origin: uid);
             return;
         }
 

--- a/Resources/Prototypes/Entities/Objects/Fun/immovable_rod.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/immovable_rod.yml
@@ -11,6 +11,9 @@
     state: icon
     noRot: false
   - type: ImmovableRod
+    damage:
+      types:
+        Piercing: 300
   - type: TimedDespawn
     lifetime: 30.0
   - type: Physics


### PR DESCRIPTION
## About the PR
Instead of gibbing a body, the immovable rod deals unblockable damage, currently set to 300 piercing.

**This is marked as a draft** because I don't know if the feature is desirable, and also the rest of the repo doesn't seem to build reliably following the latest upstream merge. Once everything is working, I can undraft it.

## Why / Balance
Based on discussion with @TsjipTsjip, one issue with the immovable rod is that it just straight-up round-removes people. Instead of gibbing a body (and then instantly deleting the body parts due to the rod colliding with them in the same frame), deal a high amount of unblockable damage. It will still definitely kill you and will require a lot of work to bring you back, but you can be saved by a competent medical team.

## Technical details
* ImmovableRodComponent gets a new field: `Damage`.
* ImmovableRodSystem uses the field when the rod collides, dealing damage instead of gibbing.
* Immovable rod prototype assigns a damage specifier.

Pretty straightforward, all things considered. :)

## Media
https://github.com/Umbra-Cosmatic-Drift/Umbra-CD/assets/30327355/66d3a63b-cf3b-4097-992a-cd111fc736db

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
Probably not needed.