### PR TITLE
Restore missing migrations

### DIFF
--- a/Resources/migration.yml
+++ b/Resources/migration.yml
@@ -192,6 +192,26 @@ Observationskit: null
 # 2024-02-26
 CrateBaseWeldable: CrateGenericSteel
 
+# 2024-03-7
+AirlockExternalEasyPry: AirlockExternal
+AirlockExternalGlassEasyPry: AirlockExternalGlass
+AirlockGlassShuttleEasyPry: AirlockGlassShuttle
+AirlockShuttleEasyPry: AirlockShuttle
+AirlockExternalEasyPryLocked: AirlockExternalLocked
+AirlockExternalGlassEasyPryLocked: AirlockExternalGlassLocked
+AirlockGlassShuttleEasyPryLocked: AirlockExternalGlassShuttleLocked
+AirlockShuttleEasyPryLocked: AirlockExternalShuttleLocked
+
+#2024-03-10
+ClothingBackpackFilledDetective: ClothingBackpackSecurityFilledDetective
+ClothingBackpackDuffelFilledDetective: ClothingBackpackDuffelSecurityFilledDetective
+ClothingBackpackSatchelFilledDetective: ClothingBackpackSatchelSecurityFilledDetective
+
+# 2024-03-11
+ImprovisedExplosive: FireBomb
+ImprovisedExplosiveEmpty: FireBombEmpty
+ImprovisedExplosiveFuel: FireBombFuel
+
 # 2024-03-12 (UMBRA)
 MysteryFigureBox: MysteryFigureBoxUmbra
 VendingMachineGames: VendingMachineGamesUmbra


### PR DESCRIPTION
## About the PR
Restores some necessary missing migrations that were removed by a botched merge in #40 (commit 80a9a1bd6daf34792a8b73bb2cebe02b72513144).

## Why / Balance
With this PR, it should be possible to play on Core, Atlas and Train again! And the arrivals terminal should load, too!

## Technical details
.yml

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
ideally not!

**Changelog**
N/A